### PR TITLE
Fixed relaxed clock operators

### DIFF
--- a/src/lphybeast/BEASTContext.java
+++ b/src/lphybeast/BEASTContext.java
@@ -1319,6 +1319,10 @@ public class BEASTContext {
         return xml;
     }
 
+    public void addSkipOperator(StateNode stateNode) {
+        skipOperators.add(stateNode);
+    }
+
     public void addExtraOperator(Operator operator) {
         extraOperators.add(operator);
     }

--- a/src/lphybeast/Exclusion.java
+++ b/src/lphybeast/Exclusion.java
@@ -44,6 +44,7 @@ public class Exclusion {
                 generator instanceof ExpressionNode || generator instanceof RandomComposition ||
                 generator instanceof NTaxaFunction || generator instanceof NCharFunction ||
                 generator instanceof CreateTaxa || generator instanceof TaxaFunction ||
+                generator instanceof lphy.core.functions.NodeCount ||
                 generator instanceof Species || generator instanceof TaxaAgesFromFunction ||
                 generator instanceof ReadNexus || generator instanceof ReadFasta ||
                 generator instanceof ExtractTrait || generator instanceof Unique ||

--- a/src/lphybeast/tobeast/generators/PhyloCTMCToBEAST.java
+++ b/src/lphybeast/tobeast/generators/PhyloCTMCToBEAST.java
@@ -169,6 +169,7 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
                 relaxedClockModel.setInputValue("rates", beastBranchRates);
                 relaxedClockModel.setInputValue("tree", tree);
                 relaxedClockModel.setInputValue("distr", logNormalPrior.distInput.get());
+                relaxedClockModel.setID("relaxedClock");
                 relaxedClockModel.initAndValidate();
                 treeLikelihood.setInputValue("branchRateModel", relaxedClockModel);
 
@@ -262,6 +263,7 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
         inConstantDistanceOperator.setInputValue("rates", rates);
         inConstantDistanceOperator.setInputValue("twindowSize", tWindowSize);
         inConstantDistanceOperator.setInputValue("weight", BEASTContext.getOperatorWeight(tree.getNodeCount()));
+        inConstantDistanceOperator.setID(relaxedClockModel.getID() + ".inConstantDistanceOperator");
         inConstantDistanceOperator.initAndValidate();
         context.addExtraOperator(inConstantDistanceOperator);
 
@@ -271,6 +273,7 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
         simpleDistance.setInputValue("rates", rates);
         simpleDistance.setInputValue("twindowSize", tWindowSize);
         simpleDistance.setInputValue("weight", BEASTContext.getOperatorWeight(2));
+        simpleDistance.setID(relaxedClockModel.getID() + ".simpleDistance");
         simpleDistance.initAndValidate();
         context.addExtraOperator(simpleDistance);
 
@@ -280,6 +283,7 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
         bigPulley.setInputValue("twindowSize", tWindowSize);
         bigPulley.setInputValue("dwindowSize", 0.1);
         bigPulley.setInputValue("weight", BEASTContext.getOperatorWeight(2));
+        bigPulley.setID(relaxedClockModel.getID() + ".bigPulley");
         bigPulley.initAndValidate();
         context.addExtraOperator(bigPulley);
 
@@ -289,6 +293,7 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
         smallPulley.setInputValue("rates", rates);
         smallPulley.setInputValue("dwindowSize", 0.1);
         smallPulley.setInputValue("weight", BEASTContext.getOperatorWeight(2));
+        smallPulley.setID(relaxedClockModel.getID() + ".smallPulley");
         smallPulley.initAndValidate();
         context.addExtraOperator(smallPulley);
     }

--- a/src/lphybeast/tobeast/generators/PhyloCTMCToBEAST.java
+++ b/src/lphybeast/tobeast/generators/PhyloCTMCToBEAST.java
@@ -137,6 +137,7 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
         return treeLikelihood;
     }
 
+
     /**
      * Create tree and clock rate inside this tree likelihood.
      * @param phyloCTMC
@@ -144,6 +145,17 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
      * @param context
      */
     public static void constructTreeAndBranchRate(PhyloCTMC phyloCTMC, GenericTreeLikelihood treeLikelihood, BEASTContext context) {
+        constructTreeAndBranchRate(phyloCTMC, treeLikelihood, context, false);
+    }
+
+    /**
+     * Create tree and clock rate inside this tree likelihood.
+     * @param phyloCTMC
+     * @param treeLikelihood
+     * @param context
+     * @param skipBranchOperators skip constructing branch rates
+     */
+    public static void constructTreeAndBranchRate(PhyloCTMC phyloCTMC, GenericTreeLikelihood treeLikelihood, BEASTContext context, boolean skipBranchOperators) {
         Value<TimeTree> timeTreeValue = phyloCTMC.getTree();
         Tree tree = (Tree) context.getBEASTObject(timeTreeValue);
         //tree.setInputValue("taxa", value);
@@ -169,11 +181,13 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
                 relaxedClockModel.setInputValue("rates", beastBranchRates);
                 relaxedClockModel.setInputValue("tree", tree);
                 relaxedClockModel.setInputValue("distr", logNormalPrior.distInput.get());
-                relaxedClockModel.setID("relaxedClock");
+                relaxedClockModel.setID(branchRates.getCanonicalId() + ".model");
                 relaxedClockModel.initAndValidate();
                 treeLikelihood.setInputValue("branchRateModel", relaxedClockModel);
 
-                addRelaxedClockOperators(tree, relaxedClockModel, beastBranchRates, context);
+                if (skipBranchOperators == false) {
+                    addRelaxedClockOperators(tree, relaxedClockModel, beastBranchRates, context);
+                }
 
             } else if (generator instanceof LocalBranchRates) {
                 treeLikelihood.setInputValue("branchRateModel", context.getBEASTObject(generator));
@@ -182,7 +196,7 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
             }
 
             if (branchRates instanceof RandomVariable && timeTreeValue instanceof RandomVariable) {
-                throw new UnsupportedOperationException("in development");
+//                throw new UnsupportedOperationException("in development");
             }
 
         } else {
@@ -199,7 +213,7 @@ public class PhyloCTMCToBEAST implements GeneratorToBEAST<PhyloCTMC, GenericTree
             clockModel.setInputValue("clock.rate", clockRatePara);
             treeLikelihood.setInputValue("branchRateModel", clockModel);
 
-            if (clockRate instanceof RandomVariable && timeTreeValue instanceof RandomVariable) {
+            if (clockRate instanceof RandomVariable && timeTreeValue instanceof RandomVariable && skipBranchOperators == false) {
                 addUpDownOperator(tree, clockRatePara, context);
             }
         }


### PR DESCRIPTION
This pull request includes two changes:
* Added BEASTObject IDs to relaxed clock and operators in `PhyloCTMCToBEAST`
* Added method `addSkipOperator(StateNode stateNode)` in `BEASTContext` to allow skipping operators for specified state nodes.