### PR TITLE
Support offset for distributions via OffsetReal (#202)

### DIFF
--- a/lphybeast-feast/src/main/java/feast/lphybeast/tobeast/generators/ExpressionNodeToBEAST.java
+++ b/lphybeast-feast/src/main/java/feast/lphybeast/tobeast/generators/ExpressionNodeToBEAST.java
@@ -1,48 +1,176 @@
 package feast.lphybeast.tobeast.generators;
 
 import beast.base.core.BEASTInterface;
+import beast.base.inference.StateNode;
+import beast.base.spec.domain.Real;
+import beast.base.spec.inference.distribution.OffsetReal;
+import beast.base.spec.inference.distribution.ScalarDistribution;
+import beast.base.spec.inference.parameter.RealScalarParam;
+import beast.base.spec.type.RealScalar;
 import feast.expressions.ExpCalculator;
 import lphy.core.model.ExpressionNode;
+import lphy.core.model.GraphicalModelNode;
 import lphy.core.model.RandomVariable;
 import lphy.core.model.Value;
+import lphy.core.parser.function.ExpressionNode2Args;
 import lphybeast.BEASTContext;
 import lphybeast.GeneratorToBEAST;
 import lphybeast.tobeast.ExpressionUtils;
 
 import java.util.List;
 
-public class ExpressionNodeToBEAST implements GeneratorToBEAST<ExpressionNode, ExpCalculator> {
+public class ExpressionNodeToBEAST implements GeneratorToBEAST<ExpressionNode, BEASTInterface> {
+
     @Override
-    public ExpCalculator generatorToBEAST(ExpressionNode expression, BEASTInterface value, BEASTContext context) {
+    public BEASTInterface generatorToBEAST(ExpressionNode expression, BEASTInterface value, BEASTContext context) {
 
         Value output = (Value) context.getGraphicalModelNode(value);
 
-        if (ExpressionUtils.isNamedModelValue(output, context)) {
+        if (!ExpressionUtils.isNamedModelValue(output, context)) return null;
 
-            if (!output.getCanonicalId().equals(value.getID()))
-                throw new IllegalArgumentException("The LPhy expression output ID " + output.getCanonicalId() +
-                        " should match BEAST ID " + value.getID());
+        if (!output.getCanonicalId().equals(value.getID()))
+            throw new IllegalArgumentException("The LPhy expression output ID " + output.getCanonicalId() +
+                    " should match BEAST ID " + value.getID());
 
-            ExpCalculator expCalculator = new ExpCalculator();
+        BEASTInterface offsetPrior = tryOffsetReal(expression, value, context);
+        if (offsetPrior != null) return offsetPrior;
 
-            List<RandomVariable> args = ExpressionUtils.findArgs(expression);
+        return toExpCalculator(expression, value, context);
+    }
 
-            for (RandomVariable randomVariable : args) {
-                BEASTInterface beastInterface = context.getBEASTObject(randomVariable);
-                expCalculator.setInputValue("arg", beastInterface);
-            }
+    /**
+     * Detects the pattern {@code Z = Y + c}, {@code c + Y}, or {@code Y - c}, where Y is a
+     * RandomVariable used only by this deterministic and Y's prior is a {@link ScalarDistribution}
+     * over a real-valued scalar. Replaces Y's prior with an {@link OffsetReal} acting on Z's
+     * parameter, so that Z becomes the sampled state variable.
+     *
+     * @return an OffsetReal wired as Z's prior, or null if the pattern doesn't match.
+     */
+    private BEASTInterface tryOffsetReal(ExpressionNode expression, BEASTInterface value, BEASTContext context) {
+        if (!(expression instanceof ExpressionNode2Args)) return null;
+        if (!(value instanceof RealScalarParam<?>)) return null;
 
-            expCalculator.setInputValue("value", expression.getExpression());
-            expCalculator.setInputValue("useCaching", false);
-            expCalculator.setID(value.getID());
-            expCalculator.initAndValidate();
+        GraphicalModelNode[] inputs = expression.getInputValues();
+        if (inputs == null || inputs.length != 2) return null;
+        if (!(inputs[0] instanceof Value) || !(inputs[1] instanceof Value)) return null;
 
-            context.removeBEASTObject(value);
+        Value left = (Value) inputs[0];
+        Value right = (Value) inputs[1];
 
-            return expCalculator;
-
-        } else
+        // Identify which side is the random variable and which is a plain constant.
+        Value randomVar;
+        Value constantVal;
+        boolean varOnLeft;
+        if (isOffsetCandidate(left) && isPlainConstant(right)) {
+            randomVar = left;
+            constantVal = right;
+            varOnLeft = true;
+        } else if (isOffsetCandidate(right) && isPlainConstant(left)) {
+            randomVar = right;
+            constantVal = left;
+            varOnLeft = false;
+        } else {
             return null;
+        }
+
+        // The random variable must be used only by this deterministic, otherwise we can't
+        // safely subsume it into Z's prior.
+        if (randomVar.getOutputs() == null || randomVar.getOutputs().size() != 1) return null;
+
+        if (!(left.value() instanceof Number) || !(right.value() instanceof Number)) return null;
+        Object outputVal = output(expression, value, context);
+        if (!(outputVal instanceof Number)) return null;
+
+        double v0 = ((Number) left.value()).doubleValue();
+        double v1 = ((Number) right.value()).doubleValue();
+        double z = ((Number) outputVal).doubleValue();
+        double tol = 1e-9 * Math.max(1.0, Math.abs(z));
+        boolean isPlus = Math.abs(z - (v0 + v1)) <= tol;
+        boolean isMinus = Math.abs(z - (v0 - v1)) <= tol;
+        if (isPlus == isMinus) return null;  // ambiguous (e.g. constant=0) or neither + nor -
+
+        double c = ((Number) constantVal.value()).doubleValue();
+        double offset;
+        if (isPlus) {
+            offset = c;
+        } else if (varOnLeft) {
+            offset = -c;
+        } else {
+            return null;  // c - Y is not an offset; OffsetReal can't represent a sign flip
+        }
+
+        BEASTInterface yGenObj = context.getBEASTObject(randomVar.getGenerator());
+        if (!(yGenObj instanceof ScalarDistribution<?, ?> innerCheck)) return null;
+        if (innerCheck.isIntegerDistribution()) return null; // OffsetReal is real-valued only
+
+        BEASTInterface yParam = context.getBEASTObject(randomVar);
+
+        // Re-invoke Y's generator converter with value=null so the inner distribution is built
+        // without a `param` input pointing at Y's now-orphaned RealScalarParam.
+        GeneratorToBEAST yConverter = context.getGeneratorToBEAST(randomVar.getGenerator());
+        if (yConverter == null) return null;
+        BEASTInterface freshInner = yConverter.generatorToBEAST(randomVar.getGenerator(), (BEASTInterface) null, context);
+        if (!(freshInner instanceof ScalarDistribution<?, ?>)) return null;
+        freshInner.setID(value.getID() + ".dist");
+
+        @SuppressWarnings("unchecked")
+        ScalarDistribution<RealScalar<Real>, Double> innerTyped =
+                (ScalarDistribution<RealScalar<Real>, Double>) freshInner;
+
+        OffsetReal offsetReal = new OffsetReal();
+        offsetReal.setInputValue("distribution", innerTyped);
+        offsetReal.setInputValue("offset", new RealScalarParam<>(offset, Real.INSTANCE));
+        offsetReal.setInputValue("param", value);
+        offsetReal.setID(value.getID() + ".prior");
+        offsetReal.initAndValidate();
+
+        // Drop the now-subsumed BEAST objects for Y so they aren't picked up as separate
+        // state nodes or top-level priors.
+        if (yParam != null) context.removeBEASTObject(yParam);
+        context.removeBEASTObject(yGenObj);
+
+        // Z is a deterministic LPhy Value, so the standard pipeline's isState() returns false
+        // and Z's parameter wasn't added to the MCMC state. Now that Z carries the offset prior
+        // and is the actual sampled quantity, add it explicitly.
+        Value output = (Value) context.getGraphicalModelNode(value);
+        context.addStateNode((StateNode) value, output, true);
+
+        return offsetReal;
+    }
+
+    private static Object output(ExpressionNode expression, BEASTInterface value, BEASTContext context) {
+        Value out = (Value) context.getGraphicalModelNode(value);
+        return out != null ? out.value() : null;
+    }
+
+    /** Y must be a sampled random variable to qualify for offset rewriting. */
+    private static boolean isOffsetCandidate(Value v) {
+        return v instanceof RandomVariable;
+    }
+
+    /** A "plain constant" is a Value with no upstream generator (i.e. a literal). */
+    private static boolean isPlainConstant(Value v) {
+        return !(v instanceof RandomVariable) && v.getGenerator() == null;
+    }
+
+    private BEASTInterface toExpCalculator(ExpressionNode expression, BEASTInterface value, BEASTContext context) {
+        ExpCalculator expCalculator = new ExpCalculator();
+
+        List<RandomVariable> args = ExpressionUtils.findArgs(expression);
+
+        for (RandomVariable randomVariable : args) {
+            BEASTInterface beastInterface = context.getBEASTObject(randomVariable);
+            expCalculator.setInputValue("arg", beastInterface);
+        }
+
+        expCalculator.setInputValue("value", expression.getExpression());
+        expCalculator.setInputValue("useCaching", false);
+        expCalculator.setID(value.getID());
+        expCalculator.initAndValidate();
+
+        context.removeBEASTObject(value);
+
+        return expCalculator;
     }
 
     @Override
@@ -51,7 +179,7 @@ public class ExpressionNodeToBEAST implements GeneratorToBEAST<ExpressionNode, E
     }
 
     @Override
-    public Class<ExpCalculator> getBEASTClass() {
-        return ExpCalculator.class;
+    public Class<BEASTInterface> getBEASTClass() {
+        return BEASTInterface.class;
     }
 }

--- a/lphybeast-feast/src/test/java/feast/lphybeast/OffsetExpressionTest.java
+++ b/lphybeast-feast/src/test/java/feast/lphybeast/OffsetExpressionTest.java
@@ -1,0 +1,74 @@
+package feast.lphybeast;
+
+import beast.pkgmgmt.BEASTClassLoader;
+import lphybeast.LPhyBEASTLoader;
+import lphybeast.LPhyBeast;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for issue #202: support offset for distributions.
+ * <p>
+ * The expected translation: {@code Z = Y + c} (or {@code c + Y}, {@code Y - c}) where Y is a
+ * RandomVariable used only by this deterministic should produce a single sampled parameter
+ * Z whose prior is {@link beast.base.spec.inference.distribution.OffsetReal} wrapping Y's
+ * underlying ScalarDistribution.
+ */
+public class OffsetExpressionTest {
+
+    @BeforeEach
+    public void setUp() {
+        BEASTClassLoader.classLoader.addServices("lphybeast-feast", Map.of(
+                "lphybeast.spi.LPhyBEASTMapping", Set.of("feast.lphybeast.spi.FeastLBImpl"),
+                "lphybeast.spi.ValueHandler", Set.of("feast.lphybeast.FeastValueHandler")
+        ));
+        LPhyBEASTLoader.loadServicesForTest(System.getProperty("user.dir") + "/../lphybeast");
+    }
+
+    @Test
+    public void testOffsetExpForBirthDeath() throws IOException {
+        String script = """
+                data {
+                  L = 200;
+                  taxa = taxa(names=1:10);
+                }
+                model {
+                  div ~ Exp(mean=0.1);
+                  diversification = div + 0.1;
+                  turnover ~ Beta(alpha=2.0, beta=2.0);
+                  rootAge ~ LogNormal(meanlog=2.366645, sdlog=0.25);
+                  T ~ BirthDeathSampling(diversification=diversification, turnover=turnover, rho=0.5, rootAge=rootAge);
+                  D ~ PhyloCTMC(tree=T, L=L, Q=jukesCantor());
+                }""";
+
+        String xml = new LPhyBeast().lphyStrToXML(script, "offsetExp");
+        assertNotNull(xml);
+
+        assertTrue(xml.contains("OffsetReal"), "OffsetReal present in XML");
+        assertTrue(xml.contains("id=\"diversification.prior\""), "OffsetReal wired with id <param>.prior");
+        assertTrue(xml.contains("id=\"diversification\""), "diversification is the sampled parameter");
+        assertTrue(xml.contains("birthDiffRate=\"@diversification\"") || xml.contains("@diversification"),
+                "BD model references diversification");
+        assertFalse(xml.contains("id=\"div\""), "div parameter is subsumed (not a separate state node)");
+        assertFalse(xml.contains("id=\"div.prior\""), "div's standalone Exp prior is replaced by OffsetReal");
+
+        // diversification must be a sampled state node with an operator
+        String stateBlock = xml.substring(xml.indexOf("<state"), xml.indexOf("</state>"));
+        assertTrue(stateBlock.contains("@diversification") || stateBlock.contains("id=\"diversification\""),
+                "diversification appears in <state>");
+        assertTrue(xml.contains("@diversification") &&
+                xml.contains("ScaleOperator") &&
+                xml.matches("(?s).*parameter=\"@diversification\".*"),
+                "ScaleOperator targets diversification");
+
+    }
+
+}


### PR DESCRIPTION
Closes LinguaPhylo/LPhyBeast#202.

## Summary

Rewrites `ExpressionNodeToBEAST` to detect simple offset patterns and lower them onto beast3's `OffsetReal` distribution.

For an LPhy expression like:

```
div ~ Exp(mean=0.1);
diversification = div + 0.1;
T ~ BirthDeathSampling(diversification=diversification, ...);
```

the converter now emits a single sampled `RealScalarParam` named `diversification` with prior `OffsetReal(distribution=Exp(mean=0.1), offset=0.1)`. `div` is subsumed: no separate state node, no separate prior. BD reads `diversification` directly.

Detection covers:
- `Y + c`, `c + Y` → `OffsetReal(..., offset=c)`
- `Y - c` → `OffsetReal(..., offset=-c)`
- Skip when Y has multiple consumers, when the operand is non-numeric, when the inner distribution is integer-valued, when the deterministic is not a simple binary `+`/`-`.

Anything that does not match falls through to the existing `ExpCalculator` path.

## Why the prior behaviour was wrong

Without this change, `diversification = div + 0.1` produced two unrelated `RealScalarParam`s in the BEAST XML: `div` sampled from `Exp` and `diversification` as a free parameter with no prior. The deterministic relationship was lost entirely.

## Runtime dependency

The XML produced is structurally correct. End-to-end MCMC requires beast3 with the `OffsetReal.calculateLogP` fix from CompEvol/beast3#73; without it, `P(diversification.prior) = -Infinity` at every state and the chain cannot initialise. So this PR is gated on a beast3 release that includes that fix (likely beta6).

## Test plan

- [x] New `lphybeast-feast/src/test/java/feast/lphybeast/OffsetExpressionTest.java` runs the issue's BirthDeath script and asserts: `OffsetReal` present, `diversification.prior` id, `birthDiffRate=@diversification`, `div` subsumed, `diversification` in `<state>`, `ScaleOperator` targeting it. Passes against `2.8.0-beta4`.
- [x] Existing `LPhyScriptsToBEASTTest` (simpleCoalescent + relaxClock) still pass.
- [x] End-to-end MCMC verified by running `mvn -pl lphybeast-launcher -P feast exec:exec -Dlphybeast.args="run -l 10000 ..."` against beast3 with CompEvol/beast3#73 applied: clean run, ~36% acceptance on `diversification.scale`. Same command against unfixed beta5 fails with `-Infinity` posterior at init (expected, demonstrates the gating).
